### PR TITLE
로거 설정 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,9 @@ spring:
     password: ${LOCAL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  profiles:
+    active: local # 또는 dev
+
   jpa:
     show-sql: true # JPA가 실행하는 SQL 쿼리를 출력하도록 설정
     properties:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- 60초마다 설정 파일의 변경을 확인하여 변경시 갱신 -->
+<configuration scan="true" scanPeriod="60 seconds">
+    <!-- 로그 패턴에 색상 적용 %clr(pattern){color} https://logback.qos.ch/manual/layouts.html#coloring -->
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
+
+    <!-- springProfile 태그를 사용하여 profile 별 property 값 설정 -->
+    <springProfile name="local">
+        <!-- local log file path -->
+        <property name="LOG_PATH" value="/gc-coffee/log"/>
+    </springProfile>
+    <springProfile name="dev">
+        <!-- dev log file path -->
+        <property name="LOG_PATH" value="/home/ge-coffee/log"/>
+    </springProfile>
+
+    <!-- Environment 내의 프로퍼티들을 개별적으로 설정 -->
+    <springProperty scope="context" name="LOG_LEVEL" source="logging.level.root"/>
+
+    <!-- log file name -->
+    <property name="LOG_FILE_NAME" value="gc-coffee"/>
+    <!-- err log file name -->
+    <property name="ERR_LOG_FILE_NAME" value="gc-coffee_err"/>
+    <!-- console log pattern -->
+    <property name="CONSOLE_LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative]  %clr(%-5level) %clr(${PID:-}){magenta} %clr(---){faint} %clr([%15.15thread]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} %msg%n"/>
+    <!-- file log pattern -->
+    <property name="FILE_LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] %-5level ${PID:-} --- [%15.15thread] %-40.40logger{36} : %msg%n"/>
+
+    <!-- Console Appender -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- File Appender -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <!-- 파일경로 설정 -->
+        <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file>
+
+        <!-- 출력패턴 설정 -->
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+
+        <!-- Rolling 정책 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- .gz .zip 등을 넣으면 자동 일자별 로그 파일 압축 -->
+            <fileNamePattern>${LOG_PATH}/${LOG_FILE_NAME}.%d{yyyy-MM-dd}_%i.gz</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <!-- 파일당 최고 용량 kb, mb, gb -->
+                <maxFileSize>10KB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <!-- 일자별 로그 파일 최대 보관주기(~일), 해당 설정일 이상된 파일은 자동으로 제거 -->
+            <maxHistory>30</maxHistory>
+            <!-- 전체 파일 크기를 제어하며, 전체 크기 제한을 조과하면 가장 오래된 파일을 삭제 -->
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <!-- 에러의 경우 파일에 로그 처리 -->
+    <appender name="ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>error</level>
+            <onMatch>ACCEPT</onMatch> <!-- 로그가 에러일 경우에만 수락 -->
+            <onMismatch>DENY</onMismatch> <!-- error level 보다 낮으면 무시(DENY)  -->
+        </filter>
+        <file>${LOG_PATH}/${ERR_LOG_FILE_NAME}.log</file>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+
+        <!-- Rolling 정책 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- .gz .zip 등을 넣으면 자동 일자별 로그파일 압축 -->
+            <fileNamePattern>${LOG_PATH}/${ERR_LOG_FILE_NAME}.%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <!-- 파일당 최고 용량 kb, mb, gb -->
+                <maxFileSize>10KB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <!-- 일자별 로그 파일 최대 보관주기(~일), 해당 설정일 이상된 파일은 자동으로 제거 -->
+            <maxHistory>60</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <!-- root 레벨 설정 -->
+    <root level="${LOG_LEVEL}">
+        <appender-ref ref="CONSOLE"/>
+<!--        <appender-ref ref="FILE"/>-->
+<!--        <appender-ref ref="ERROR"/>-->
+    </root>
+
+    <!-- spring -->
+    <logger name="org.springframework" level="WARN" />
+
+    <!-- datasource -->
+    <logger name="org.hibernate" level="WARN "/>
+    <logger name="com.zaxxer.hikari" level="WARN "/>
+
+    <!-- gc-coffee -->
+    <logger name="org.example.gc_coffee" level="TRACE"/>
+
+    <logger name="ROOT" level="DEBUG" />
+</configuration>


### PR DESCRIPTION
📌 _**로그 설정 관리 파일 추가**_
- properties/application.yml 에서 profile.active 설정 추가
- properteis/logback-spring.xml 로그 관리 파일 추가

👩‍💻 _**요구 사항과 구현 내용**_
1. 콘솔-로그 : 커스텀 로그 표시 설정, 로그 레벨을 설정하여 로그 구분
2. 파일-로그 : 특정 디렉토리로 모든 로그 저장 및 관리 가능 (기능만 구현하고 임시 주석처리된 상태)
3. 에러-로그 : 특정 디렉토리로 에러 로그만 저장 및 관리 기능 추가 (기능만 구현하고 임시 주석처리된 상태)

------------------

📚 _**로그_ 설정 파일이 뭔가요 !?**

![image](https://github.com/user-attachments/assets/a57a5769-a3da-4587-aa26-989860b0a184)

`logback-spring.xml` 설정 파일은 로그 출력과 관리에 대한 여러 이점을 제공합니다.

logback-spring.xml 설정 파일을 통한 핵심 관리 사항입니다.

- **프로파일별 설정**: `local`과 `dev` 등 다양한 환경에 맞춘 로그 경로 설정이 가능하여, 개발, 테스트, 운영 환경에서 다른 로그 파일을 저장할 수 있음.
![image](https://github.com/user-attachments/assets/07b7af32-507b-403b-8789-0319f22f01df)

- **자동 로그 롤링**: 용량과 시간에 따른 로그 파일 관리가 가능하며, 오래된 로그 파일은 자동으로 삭제되고, 파일 크기 초과 시 압축 처리됨.
![image](https://github.com/user-attachments/assets/c8a64137-8063-42b1-8035-3e014d647d06)

- **에러 로그 분리**: 에러 로그를 별도의 파일로 분리해 관리, 에러에 대한 추적을 용이하게 함.
![image](https://github.com/user-attachments/assets/312d38ba-66d3-4663-8d93-a1ca67525031)

- **로그 색상 및 형식 커스터마이징**: 콘솔 로그에 색상을 적용하여 가독성을 높이며, 로그 패턴을 지정하여 일관된 로그 형식 제공.
![image](https://github.com/user-attachments/assets/36b6f16d-6d6f-4d15-9e6a-3814c54c47f2)
![image](https://github.com/user-attachments/assets/3322e5f4-ce66-4c48-b5ff-569a00a5492e)
![image](https://github.com/user-attachments/assets/5e068c12-623b-4079-accc-eaf61ed24534)

------------------

윈도우 환경에서 다음과 같이 로그를 관리할 수 있습니다.


 > 현재 xml 에는 Console 로그 설정, File(전체 로그) 저장, Error(에러 로그만) 저장에 대해서 기술되어 있습니다.
![image](https://github.com/user-attachments/assets/2e29fa62-2d52-4613-b9d9-b43d366b2534)

------------------

🛠️ **_xml 내의 주요 코드와 그 역할을 요약한 것입니다._**

1. Profile 별 설정

| 프로파일 | 로그 경로 | 로그 파일 이름 | 에러 로그 파일 이름 |
|:--------------:|:--------------:|:--------------:|:--------------:|
local|/gc-coffee/log|gc-coffee.log|gc-coffee_err.log|

각 환경(local, dev)에 따라 로그가 저장될 경로를 다르게 설정하며, 
일반 로그 파일과 에러 로그 파일을 별도로 관리하여 유지 보수를 용이하게 합니다.

2. Appender 설정

| Appender 종류 | 출력 경로 | 로그 패턴 | 최대 파일 크기 | 최대 보관 기간 |
|:--------------:|:--------------:|:--------------:|:--------------:|:--------------:|
콘솔 | 콘솔 출력 | 색상이 적용된 패턴 | 해당 없음 | 해당 없음
파일 | ${LOG_PATH}/gc-coffee.log | 표준 파일 패턴 | 10KB | 30일
에러 파일 | ${LOG_PATH}/gc-coffee_err.log | 표준 파일 패턴 | 1

콘솔: 콘솔에 로그를 출력하며, 가독성을 위해 색상이 적용된 패턴을 사용합니다.
파일: 로그 파일로 출력되며, 10KB를 초과하면 새로운 파일을 생성하고 30일 동안 로그를 보관합니다.
에러 파일: 에러 로그는 별도로 관리되며, 최대 60일간 보관 후 삭제됩니다.

3. 로거 설정

| 로거 이름 | 로그 레벨 |
|:--------------:|:--------------:|
org.springframework | WARN |
org.hibernate | WARN |
com.zaxxer.hikari | WARN |
org.example.gc_coffee | TRACE |
ROOT | DEBUG |

각 로거의 로그 레벨을 설정하여 불필요한 로그 출력을 줄입니다.
Spring, Hibernate, HikariCP와 같은 주요 패키지는 WARN 레벨로 설정되어 경고 이상의 로그만 출력되며, 커스텀 로거 org.example.gc_coffee는 TRACE 레벨로 더 세밀한 로그를 기록합니다.
ROOT 로거는 전체적으로 DEBUG 레벨을 적용하여 애플리케이션 전반의 로그를 디버깅 용도로 출력합니다.

4. 롤링 정책 설정

| 롤링 정책| 최대 파일 크기 | 최대 보관 기간 | 전체 크기 제한 |
|:--------------:|:--------------:|:--------------:|:--------------:|
시간 및 크기 기반 롤링 | 10KB | 30일 | 1GB |

시간과 파일 크기를 기준으로 로그 파일이 관리되며, 파일이 10KB를 초과하면 새 파일이 생성됩니다.
최대 30일 동안 로그 파일을 보관하며, 전체 로그 파일 크기가 1GB를 넘으면 가장 오래된 파일부터 삭제합니다.


※ 각 프로젝트 환경에 맞게 로그 XML 내의 기술을 변경하여 활용하실 수 있습니다!