### PR TITLE
feat: swagger tag 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.3'
     id 'io.spring.dependency-management' version '1.1.6'
+    //rest doc
+    id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
 group = 'org.example'
@@ -17,6 +19,8 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    //rest doc
+    asciidoctorExt
 }
 
 repositories {
@@ -38,6 +42,30 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
+    //rest doc
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor:{project-version}'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:{project-version}'
+
+}
+
+//rest doc
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+
+//rest doc
+test {
+    outputs.dir snippetsDir
+}
+
+//rest doc
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    dependsOn test
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/gc_coffee/config/SecurityConfig.java
+++ b/src/main/java/org/example/gc_coffee/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable) // Basic 인증 환경이 아니라 JWT 토큰이니까 Basic 모드 비활성화
                 .sessionManagement(AbstractHttpConfigurer::disable) // session 기반 인증 비활성화 (JWT 기반)
                 .authorizeHttpRequests(req ->
-                        req.requestMatchers("/**").permitAll()
+                        req.requestMatchers("**").permitAll()
                 )
                 .build();
     }

--- a/src/main/java/org/example/gc_coffee/controller/OrderController.java
+++ b/src/main/java/org/example/gc_coffee/controller/OrderController.java
@@ -1,5 +1,7 @@
 package org.example.gc_coffee.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.gc_coffee.dto.request.OrderReqDto;
@@ -17,18 +19,24 @@ public class OrderController {
 
     private final OrderService orderService;
 
+    @Operation(summary = "getOrderByEmail", description = "Email을 통한 주문 검색")
+    @ApiResponse(responseCode = "200", description = "성공")
     @GetMapping("/{email}")
     public ApiResponseDto<List<OrderResDto>> getOrderByEmail(@PathVariable(value = "email") String email) {
         List<OrderResDto> orderResDtoList = orderService.getOrderByEmail(email);
         return new ApiResponseDto<>("Order retrieved successfully", orderResDtoList);
     }
 
+    @Operation(summary = "getAllOrder", description = "모든 주문 데이터 조회")
+    @ApiResponse(responseCode = "200", description = "성공")
     @GetMapping("/all")
     public ApiResponseDto<List<OrderResDto>> getAllOrder() {
         List<OrderResDto> orders = orderService.getAllOrders();
         return new ApiResponseDto<>("Orders retrieved successfully", orders);
     }
 
+    @Operation(summary = "registerOrder", description = "주문 데이터 생성")
+    @ApiResponse(responseCode = "201", description = "성공")
     @PostMapping
     public ApiResponseDto<String> registerOrder(@RequestBody @Valid OrderReqDto orderReqDto) {
         orderService.registerOrder(orderReqDto);

--- a/src/main/java/org/example/gc_coffee/controller/ProductController.java
+++ b/src/main/java/org/example/gc_coffee/controller/ProductController.java
@@ -1,5 +1,7 @@
 package org.example.gc_coffee.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.example.gc_coffee.dto.request.ProductReqDto;
 import org.example.gc_coffee.dto.response.ProductResDto;
@@ -16,18 +18,25 @@ public class ProductController {
 
     private final ProductService productService;
 
+    @Operation(summary = "getProductByname", description = "상품 이름으로 조회")
+    @ApiResponse(responseCode = "200", description = "성공")
     @GetMapping("/{name}")
     public ApiResponseDto<ProductResDto> getProductByName(@PathVariable(value = "name") String name) {
         ProductResDto product = productService.getProductByNames(name);
         return new ApiResponseDto<>("Product retrieved successfully", product);
     }
 
+    @Operation(summary = "getAllProducts", description = "모든 상품 조회")
+    @ApiResponse(responseCode = "200", description = "성공")
     @GetMapping("/all")
     public ApiResponseDto<List<ProductResDto>> getAllProducts() {
         List<ProductResDto> products = productService.getAllProducts();
         return new ApiResponseDto<>("All products retrieved successfully", products);
     }
 
+
+    @Operation(summary = "register Product", description = "상품 등록")
+    @ApiResponse(responseCode = "201", description = "성공")
     @PostMapping
     public ApiResponseDto<String> registerProduct(@RequestBody ProductReqDto productReqDto) {
         productService.registerProduct(productReqDto);

--- a/src/main/java/org/example/gc_coffee/dto/request/OrderProductReqDto.java
+++ b/src/main/java/org/example/gc_coffee/dto/request/OrderProductReqDto.java
@@ -1,5 +1,6 @@
 package org.example.gc_coffee.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.example.gc_coffee.entity.Order;
@@ -8,6 +9,7 @@ import org.example.gc_coffee.entity.Product;
 
 import java.util.UUID;
 
+@Schema(description = "OrderProduct create request")
 public record OrderProductReqDto(
         @NotNull(message = "상품 ID를 입력해주세요.")
         UUID productId,
@@ -18,6 +20,7 @@ public record OrderProductReqDto(
         @NotNull(message = "가격을 입력해주세요.")
         Long price,
 
+        @Schema(description = "상품 수량 정보", implementation = OrderProduct.class)
         @NotNull(message = "수량을 입력해주세요.")
         Integer quantity
 ) {

--- a/src/main/java/org/example/gc_coffee/dto/request/OrderReqDto.java
+++ b/src/main/java/org/example/gc_coffee/dto/request/OrderReqDto.java
@@ -1,5 +1,6 @@
 package org.example.gc_coffee.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -10,6 +11,7 @@ import org.example.gc_coffee.entity.OrderProduct;
 
 import java.util.List;
 
+@Schema(description = "Order create request")
 public record OrderReqDto(
         @NotBlank(message = "이메일을 입력해주세요.")
         @Pattern(

--- a/src/main/java/org/example/gc_coffee/dto/request/ProductReqDto.java
+++ b/src/main/java/org/example/gc_coffee/dto/request/ProductReqDto.java
@@ -1,9 +1,11 @@
 package org.example.gc_coffee.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.example.gc_coffee.entity.Product;
 
+@Schema(description = "Product create request")
 public record ProductReqDto(
         @NotBlank(message = "제품명을 입력해주세요.")
         String name,

--- a/src/main/java/org/example/gc_coffee/dto/response/OrderProductResDto.java
+++ b/src/main/java/org/example/gc_coffee/dto/response/OrderProductResDto.java
@@ -1,5 +1,6 @@
 package org.example.gc_coffee.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.example.gc_coffee.entity.Order;
 import org.example.gc_coffee.entity.OrderProduct;
 import org.example.gc_coffee.entity.Product;
@@ -7,6 +8,7 @@ import org.example.gc_coffee.entity.Product;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+@Schema(description = "OrderProduct api response request")
 public record OrderProductResDto(
         Long seq,
         UUID orderId,

--- a/src/main/java/org/example/gc_coffee/dto/response/OrderResDto.java
+++ b/src/main/java/org/example/gc_coffee/dto/response/OrderResDto.java
@@ -1,5 +1,6 @@
 package org.example.gc_coffee.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.example.gc_coffee.dto.common.OrderStatus;
 import org.example.gc_coffee.entity.Order;
 
@@ -7,6 +8,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+@Schema(description = "Order api response request")
 public record OrderResDto(
         UUID id,
         String email,

--- a/src/main/java/org/example/gc_coffee/dto/response/ProductResDto.java
+++ b/src/main/java/org/example/gc_coffee/dto/response/ProductResDto.java
@@ -1,9 +1,12 @@
 package org.example.gc_coffee.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.example.gc_coffee.entity.Product;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+
+@Schema(description = "Product api response request")
 public record ProductResDto(
         UUID id,
         String name,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,41 @@ spring:
     properties:
       hibernate:
         format_sql: true # 출력되는 SQL을 보기 좋게 정렬
+
+
+  springdoc:
+    swagger-ui:
+      # swagger-ui 접근 경로. default 값은 local~~~~~/swagger-ui.html
+      path: /swagger-custom-ui.html
+
+      # path, query, body, response 순으로 출력
+      groups-order: DESC
+
+      # 태그 정렬 순서.
+      tags-sorter: alpha
+
+      # 컨트롤러 정렬 순서.
+      operations-sorter: method
+
+      # swagger-ui default url인 petstore html의 비활성화 설정
+      disable-swagger-default-url: true
+
+      # swagger-ui에서 try 했을 때 request duration을 알려주는 설정
+      display-request-duration: true
+
+    # openAPI 접근 경로. default 값은 /v3/api-docs 이다.
+    api-docs:
+      path: /api-docs
+
+    # Spring Actuator의 endpoint까지 보여줄 것인지?
+    show-actuator: true
+
+    # request media type 의 기본 값
+    default-consumes-media-type: application/json
+
+    # response media type 의 기본 값
+    default-produces-media-type: application/json
+
+    # 해당 패턴에 매칭되는 controller만 swagger-ui에 노출한다.
+    paths-to-match:
+      - /api/**


### PR DESCRIPTION
- swagger를 위한 설정이 yml에 추가 되었습니다.

- swagger, rest doc에 대한 의존성, 설정이 gradle에 추가되었습니다.

- 스웨거 문서 확인 url : 
   http://localhost:8080/swagger-ui/index.html#/ 
   /swagger-ui 이전 url은 개인의 설정에 따라 다를수 있습니다.

- 코드 가독성으로 인해 컨트롤러, dto에 간략한 태그만 남겼습니다.

## Swagger를 통한 API 명세서 작성

### 설명

Swagger를 이용해 API 명세서를 자동으로 생성하고, `swagger-ui`를 통해 명세서를 시각적으로 확인할 수 있도록 설정했습니다. 이는 개발자와 클라이언트 간의 API 통신 문서화를 효율적으로 진행할 수 있게 해줍니다.

### 주요 기능:

- Swagger UI에서 API를 시각적으로 테스트 가능
- 각 API의 요청/응답 형식을 자동으로 명세화
- 태그별로 API를 그룹화하여 보기 쉽게 정렬

### 주요 설정

`application.yml`에서 Swagger 설정을 통해 UI의 동작 방식을 제어할 수 있습니다.

```yaml
yaml
코드 복사
springdoc:
  swagger-ui:
    path: /swagger-custom-ui.html
    groups-order: DESC
    tags-sorter: alpha
    operations-sorter: method
    disable-swagger-default-url: true
    display-request-duration: true
  api-docs:
    path: /api-docs
  show-actuator: true

```

### 이미지 예시

![스크린샷 2024-09-12 오후 3.02.22.png](https://prod-files-secure.s3.us-west-2.amazonaws.com/b6dcba97-8494-4f52-9498-534bda4b0372/fd49fadd-15c7-44fb-9eab-114c65203fc7/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA_2024-09-12_%E1%84%8B%E1%85%A9%E1%84%92%E1%85%AE_3.02.22.png)

## 

