### PR TITLE
feat: query DSL 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build/
 bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/
+!**/src/main/generated
 
 ### IntelliJ IDEA ###
 .idea
@@ -36,3 +37,4 @@ out/
 
 ### VS Code ###
 .vscode/
+

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,12 @@ dependencies {
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor:{project-version}'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:{project-version}'
 
+    //QueryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 }
 
 //rest doc

--- a/src/main/java/org/example/gc_coffee/repository/DslOrderRepository.java
+++ b/src/main/java/org/example/gc_coffee/repository/DslOrderRepository.java
@@ -1,0 +1,11 @@
+package org.example.gc_coffee.repository;
+
+import org.example.gc_coffee.entity.Order;
+
+import java.util.List;
+
+public interface DslOrderRepository {
+
+    public List<Order> findAllByEmailWithOrderProducts(String email);
+    public List<Order> findAllWithOrderProducts();
+}

--- a/src/main/java/org/example/gc_coffee/repository/DslOrderRepositoryImpl.java
+++ b/src/main/java/org/example/gc_coffee/repository/DslOrderRepositoryImpl.java
@@ -1,0 +1,44 @@
+package org.example.gc_coffee.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.example.gc_coffee.entity.Order;
+import org.example.gc_coffee.entity.QOrder;
+import org.example.gc_coffee.entity.QOrderProduct;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public class DslOrderRepositoryImpl implements DslOrderRepository {
+
+    private JPAQueryFactory jpaQueryFactory;
+
+    public DslOrderRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    @Override
+    public List<Order> findAllByEmailWithOrderProducts(String email) {
+        QOrder order = QOrder.order;
+        QOrderProduct orderProduct = QOrderProduct.orderProduct;
+
+        return jpaQueryFactory
+                .selectFrom(order)
+                .join(order.orderProducts, orderProduct).fetchJoin() // FETCH JOIN
+                .where(order.email.eq(email))
+                .fetch();
+    }
+
+    @Override
+    public List<Order> findAllWithOrderProducts() {
+        QOrder order = QOrder.order;
+        QOrderProduct orderProduct = QOrderProduct.orderProduct;
+
+        return jpaQueryFactory
+                .selectFrom(order)
+                .join(order.orderProducts, orderProduct).fetchJoin() // FETCH JOIN
+                .fetch();
+    }
+
+
+}

--- a/src/main/java/org/example/gc_coffee/repository/OrderRepository.java
+++ b/src/main/java/org/example/gc_coffee/repository/OrderRepository.java
@@ -9,12 +9,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface OrderRepository  extends JpaRepository<Order, UUID> {
+public interface OrderRepository  extends JpaRepository<Order, UUID>, DslOrderRepository{
     Optional<Order> findByEmail(String email);
 
-    @Query("SELECT o FROM Order o JOIN FETCH o.orderProducts WHERE o.email = :email")
-    List<Order> findAllByEmailWithOrderProducts(@Param("email") String email);
 
-    @Query("SELECT o FROM Order o JOIN FETCH o.orderProducts")
-    List<Order> findAllWithOrderProducts();
 }


### PR DESCRIPTION
- 빌드 환경 - 빌드 도구에서 intelliJ를 빌드 환경으로 설정 해주세요.

- 1회 빌드후 src/main/generated 디렉토리에 q클래스가 생성되었는지 확인해주세요

- query DSL 의존성 추가 gradle 하단에 해당 의존성 위에 주석으로 표시해놨습니다.

- OrderRepository에 있던 Query 에너테이션이 붙은 메서드들을 QueryDsl로 변경해주었습니다

- repository 디렉토리의 DslOrderRepositoryImpl에 해당 메서드가 존재합니다. 기존 OrderRepository에 상속을 하여 기존 로직에는 변경이 없도록 하였습니다.

## 1. Fetch Join을 활용한 QueryDSL 쿼리 관리

### 설명

QueryDSL을 사용하여 복잡한 쿼리를 빌더 패턴으로 관리할 수 있도록 했습니다. 기존의 String 기반 쿼리문 대신, 보다 구조화된 코드로 쿼리를 작성하게 되어 유지보수성과 가독성이 향상되었습니다.

### 주요 변경 사항:

- 기존에 `@Query` 어노테이션을 사용한 JPQL 쿼리를 QueryDSL로 변환
- 복잡한 조인 및 필터링 로직을 메서드 체인으로 작성 가능
- Fetch Join을 사용하여 관련 엔티티를 함께 로드

### 예시 코드

```java
java
코드 복사
// 기존 JPQL 방식
@Query("SELECT o FROM Order o JOIN FETCH o.orderProducts WHERE o.email = :email")
List<Order> findAllByEmailWithOrderProducts(@Param("email") String email);

// QueryDSL 방식
public List<Order> findAllByEmailWithOrderProducts(String email) {
    QOrder order = QOrder.order;
    return jpaQueryFactory
        .selectFrom(order)
        .leftJoin(order.orderProducts).fetchJoin()
        .where(order.email.eq(email))
        .fetch();
}

```

### 이미지 예시

![스크린샷 2024-09-12 오후 3.02.46.png](https://prod-files-secure.s3.us-west-2.amazonaws.com/b6dcba97-8494-4f52-9498-534bda4b0372/10043af9-db66-4aa1-8528-a2e06142486b/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA_2024-09-12_%E1%84%8B%E1%85%A9%E1%84%92%E1%85%AE_3.02.46.png)

---

##